### PR TITLE
Adding engine and heap backing to %tempora.instant%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ soavec_derive = "0.1.1"
 unicode-normalization = "0.1.24"
 usdt = { git = "https://github.com/aapoalas/usdt.git", branch = "nova-aarch64-branch" }
 wtf8 = "0.1"
-temporal_rs = "0.0.16"
+temporal_rs = "0.1.0"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "nova_lint" }]

--- a/nova_vm/src/ecmascript/execution/weak_key.rs
+++ b/nova_vm/src/ecmascript/execution/weak_key.rs
@@ -6,12 +6,16 @@
 
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::{builtins::temporal::instant::Instant};
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "weak-refs")]
 use crate::ecmascript::builtins::{weak_map::WeakMap, weak_ref::WeakRef, weak_set::WeakSet};
 #[cfg(feature = "date")]
 use crate::ecmascript::types::DATE_DISCRIMINANT;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::types::INSTANT_DISCRIMINANT;
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::types::FLOAT_16_ARRAY_DISCRIMINANT;
 #[cfg(feature = "shared-array-buffer")]
@@ -119,6 +123,8 @@ pub(crate) enum WeakKey<'a> {
     DataView(DataView<'a>) = DATA_VIEW_DISCRIMINANT,
     #[cfg(feature = "date")]
     Date(Date<'a>) = DATE_DISCRIMINANT,
+    #[cfg(feature = "temporal")]
+    Instant(Instant<'a>) = INSTANT_DISCRIMINANT,
     Error(Error<'a>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'a>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'a>) = MAP_DISCRIMINANT,
@@ -202,6 +208,8 @@ impl<'a> From<WeakKey<'a>> for Value<'a> {
             WeakKey::DataView(d) => Self::DataView(d),
             #[cfg(feature = "date")]
             WeakKey::Date(d) => Self::Date(d),
+            #[cfg(feature = "temporal")]
+            WeakKey::Instant(d) => Self::Instant(d),
             WeakKey::Error(d) => Self::Error(d),
             WeakKey::FinalizationRegistry(d) => Self::FinalizationRegistry(d),
             WeakKey::Map(d) => Self::Map(d),
@@ -280,6 +288,8 @@ impl<'a> From<Object<'a>> for WeakKey<'a> {
             Object::DataView(d) => Self::DataView(d),
             #[cfg(feature = "date")]
             Object::Date(d) => Self::Date(d),
+            #[cfg(feature = "temporal")]
+            Object::Instant(d) => Self::Instant(d),
             Object::Error(d) => Self::Error(d),
             Object::FinalizationRegistry(d) => Self::FinalizationRegistry(d),
             Object::Map(d) => Self::Map(d),
@@ -362,6 +372,8 @@ impl<'a> TryFrom<WeakKey<'a>> for Object<'a> {
             WeakKey::DataView(d) => Ok(Self::DataView(d)),
             #[cfg(feature = "date")]
             WeakKey::Date(d) => Ok(Self::Date(d)),
+            #[cfg(feature = "temporal")]
+            WeakKey::Instant(d) => Ok(Self::Instant(d)),
             WeakKey::Error(d) => Ok(Self::Error(d)),
             WeakKey::FinalizationRegistry(d) => Ok(Self::FinalizationRegistry(d)),
             WeakKey::Map(d) => Ok(Self::Map(d)),
@@ -475,6 +487,8 @@ impl HeapMarkAndSweep for WeakKey<'static> {
             Self::DataView(d) => d.mark_values(queues),
             #[cfg(feature = "date")]
             Self::Date(d) => d.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            Self::Instant(d) => d.mark_values(queues),
             Self::Error(d) => d.mark_values(queues),
             Self::FinalizationRegistry(d) => d.mark_values(queues),
             Self::Map(d) => d.mark_values(queues),
@@ -551,6 +565,8 @@ impl HeapMarkAndSweep for WeakKey<'static> {
             Self::DataView(d) => d.sweep_values(compactions),
             #[cfg(feature = "date")]
             Self::Date(d) => d.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            Self::Instant(d) => d.sweep_values(compactions),
             Self::Error(d) => d.sweep_values(compactions),
             Self::FinalizationRegistry(d) => d.sweep_values(compactions),
             Self::Map(d) => d.sweep_values(compactions),
@@ -645,6 +661,8 @@ impl HeapSweepWeakReference for WeakKey<'static> {
             Self::DataView(data) => data.sweep_weak_reference(compactions).map(Self::DataView),
             #[cfg(feature = "date")]
             Self::Date(data) => data.sweep_weak_reference(compactions).map(Self::Date),
+            #[cfg(feature = "temporal")]
+            Self::Instant(data) => data.sweep_weak_reference(compactions).map(Self::Instant),
             Self::Error(data) => data.sweep_weak_reference(compactions).map(Self::Error),
             Self::FinalizationRegistry(data) => data
                 .sweep_weak_reference(compactions)

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -16,6 +16,8 @@ use std::collections::TryReserveError;
 
 #[cfg(feature = "date")]
 use super::value::DATE_DISCRIMINANT;
+#[cfg(feature = "temporal")]
+use super::value::INSTANT_DISCRIMINANT;
 #[cfg(feature = "proposal-float16array")]
 use super::value::FLOAT_16_ARRAY_DISCRIMINANT;
 #[cfg(feature = "shared-array-buffer")]
@@ -48,6 +50,8 @@ use super::{
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::Instant;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "weak-refs")]
@@ -157,6 +161,7 @@ pub enum Object<'a> {
     DataView(DataView<'a>) = DATA_VIEW_DISCRIMINANT,
     #[cfg(feature = "date")]
     Date(Date<'a>) = DATE_DISCRIMINANT,
+    Instant(Instant<'a>) = INSTANT_DISCRIMINANT,
     Error(Error<'a>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'a>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'a>) = MAP_DISCRIMINANT,
@@ -716,6 +721,7 @@ impl<'a> From<Object<'a>> for Value<'a> {
             Object::DataView(data) => Value::DataView(data.unbind()),
             #[cfg(feature = "date")]
             Object::Date(data) => Value::Date(data.unbind()),
+            Object::Instant(data) => Value::Instant(data.unbind()),
             Object::Error(data) => Value::Error(data.unbind()),
             Object::FinalizationRegistry(data) => Value::FinalizationRegistry(data.unbind()),
             Object::Map(data) => Value::Map(data.unbind()),
@@ -791,6 +797,8 @@ impl<'a> TryFrom<Value<'a>> for Object<'a> {
             Value::Array(x) => Ok(Object::from(x)),
             #[cfg(feature = "date")]
             Value::Date(x) => Ok(Object::Date(x)),
+            #[cfg(feature = "temporal")]
+            Value::Instant(x) => Ok(Object::Instant(x)),
             Value::Error(x) => Ok(Object::from(x)),
             Value::BoundFunction(x) => Ok(Object::from(x)),
             Value::BuiltinFunction(x) => Ok(Object::from(x)),
@@ -893,6 +901,8 @@ impl Hash for Object<'_> {
             Object::DataView(data) => data.get_index().hash(state),
             #[cfg(feature = "date")]
             Object::Date(data) => data.get_index().hash(state),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.get_index().hash(state),
             Object::Error(data) => data.get_index().hash(state),
             Object::FinalizationRegistry(data) => data.get_index().hash(state),
             Object::Map(data) => data.get_index().hash(state),
@@ -958,6 +968,7 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.get_backing_object(agent),
             #[cfg(feature = "date")]
             Object::Date(data) => data.get_backing_object(agent),
+            Object::Instant(data) => data.get_backing_object(agent),
             Object::Error(data) => data.get_backing_object(agent),
             Object::BoundFunction(data) => data.get_backing_object(agent),
             Object::BuiltinFunction(data) => data.get_backing_object(agent),
@@ -1047,6 +1058,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.get_or_create_backing_object(agent),
             #[cfg(feature = "date")]
             Object::Date(data) => data.get_or_create_backing_object(agent),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.get_or_create_backing_object(agent),
             Object::Error(data) => data.get_or_create_backing_object(agent),
             Object::BoundFunction(data) => data.get_or_create_backing_object(agent),
             Object::BuiltinFunction(data) => data.get_or_create_backing_object(agent),
@@ -1148,6 +1161,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.object_shape(agent),
             #[cfg(feature = "date")]
             Object::Date(data) => data.object_shape(agent),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.object_shape(agent),
             Object::Error(data) => data.object_shape(agent),
             Object::BoundFunction(data) => data.object_shape(agent),
             Object::BuiltinFunction(data) => data.object_shape(agent),
@@ -1225,6 +1240,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_extensible(agent),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_extensible(agent),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_extensible(agent),
             Object::Error(data) => data.internal_extensible(agent),
             Object::BoundFunction(data) => data.internal_extensible(agent),
             Object::BuiltinFunction(data) => data.internal_extensible(agent),
@@ -1306,6 +1323,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_set_extensible(agent, value),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_set_extensible(agent, value),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_set_extensible(agent, value),
             Object::Error(data) => data.internal_set_extensible(agent, value),
             Object::BoundFunction(data) => data.internal_set_extensible(agent, value),
             Object::BuiltinFunction(idx) => idx.internal_set_extensible(agent, value),
@@ -1409,6 +1428,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_prototype(agent),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_prototype(agent),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_prototype(agent),
             Object::Error(data) => data.internal_prototype(agent),
             Object::BoundFunction(data) => data.internal_prototype(agent),
             Object::BuiltinFunction(data) => data.internal_prototype(agent),
@@ -1490,6 +1511,8 @@ impl<'a> InternalSlots<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_set_prototype(agent, prototype),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_set_prototype(agent, prototype),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_set_prototype(agent, prototype),
             Object::Error(data) => data.internal_set_prototype(agent, prototype),
             Object::BoundFunction(data) => data.internal_set_prototype(agent, prototype),
             Object::BuiltinFunction(data) => data.internal_set_prototype(agent, prototype),
@@ -1601,6 +1624,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_get_prototype_of(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_get_prototype_of(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_get_prototype_of(agent, gc),
             Object::Error(data) => data.try_get_prototype_of(agent, gc),
             Object::BoundFunction(data) => data.try_get_prototype_of(agent, gc),
             Object::BuiltinFunction(data) => data.try_get_prototype_of(agent, gc),
@@ -1702,6 +1727,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_get_prototype_of(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_get_prototype_of(agent, gc),
             Object::Error(data) => data.internal_get_prototype_of(agent, gc),
             Object::BoundFunction(data) => data.internal_get_prototype_of(agent, gc),
             Object::BuiltinFunction(data) => data.internal_get_prototype_of(agent, gc),
@@ -1810,6 +1837,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_set_prototype_of(agent, prototype, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_set_prototype_of(agent, prototype, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_set_prototype_of(agent, prototype, gc),
             Object::Error(data) => data.try_set_prototype_of(agent, prototype, gc),
             Object::BoundFunction(data) => data.try_set_prototype_of(agent, prototype, gc),
             Object::BuiltinFunction(data) => data.try_set_prototype_of(agent, prototype, gc),
@@ -1920,6 +1949,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_set_prototype_of(agent, prototype, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_set_prototype_of(agent, prototype, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_set_prototype_of(agent, prototype, gc),
             Object::Error(data) => data.internal_set_prototype_of(agent, prototype, gc),
             Object::BoundFunction(data) => data.internal_set_prototype_of(agent, prototype, gc),
             Object::BuiltinFunction(data) => data.internal_set_prototype_of(agent, prototype, gc),
@@ -2035,6 +2066,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_is_extensible(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_is_extensible(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_is_extensible(agent, gc),
             Object::Error(data) => data.try_is_extensible(agent, gc),
             Object::BoundFunction(data) => data.try_is_extensible(agent, gc),
             Object::BuiltinFunction(data) => data.try_is_extensible(agent, gc),
@@ -2126,6 +2159,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_is_extensible(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_is_extensible(agent, gc),
             Object::Error(data) => data.internal_is_extensible(agent, gc),
             Object::BoundFunction(data) => data.internal_is_extensible(agent, gc),
             Object::BuiltinFunction(data) => data.internal_is_extensible(agent, gc),
@@ -2229,6 +2264,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_prevent_extensions(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_prevent_extensions(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_prevent_extensions(agent, gc),
             Object::Error(data) => data.try_prevent_extensions(agent, gc),
             Object::BoundFunction(data) => data.try_prevent_extensions(agent, gc),
             Object::BuiltinFunction(data) => data.try_prevent_extensions(agent, gc),
@@ -2332,6 +2369,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_prevent_extensions(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_prevent_extensions(agent, gc),
             Object::Error(data) => data.internal_prevent_extensions(agent, gc),
             Object::BoundFunction(data) => data.internal_prevent_extensions(agent, gc),
             Object::BuiltinFunction(data) => data.internal_prevent_extensions(agent, gc),
@@ -2441,6 +2480,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_get_own_property(agent, property_key, cache, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_get_own_property(agent, property_key, cache, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_get_own_property(agent, property_key, cache, gc),
             Object::Error(data) => data.try_get_own_property(agent, property_key, cache, gc),
             Object::BoundFunction(data) => {
                 data.try_get_own_property(agent, property_key, cache, gc)
@@ -2575,6 +2616,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_get_own_property(agent, property_key, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_get_own_property(agent, property_key, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_get_own_property(agent, property_key, gc),
             Object::Error(data) => data.internal_get_own_property(agent, property_key, gc),
             Object::BoundFunction(data) => data.internal_get_own_property(agent, property_key, gc),
             Object::BuiltinFunction(data) => {
@@ -2704,6 +2747,10 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             }
             #[cfg(feature = "date")]
             Object::Date(idx) => {
+                idx.try_define_own_property(agent, property_key, property_descriptor, cache, gc)
+            }
+            #[cfg(feature = "temporal")]
+            Object::Instant(idx) => {
                 idx.try_define_own_property(agent, property_key, property_descriptor, cache, gc)
             }
             Object::Error(idx) => {
@@ -2915,6 +2962,10 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::Date(idx) => {
                 idx.internal_define_own_property(agent, property_key, property_descriptor, gc)
             }
+            #[cfg(feature = "temporal")]
+            Object::Instant(idx) => {
+                idx.internal_define_own_property(agent, property_key, property_descriptor, gc)
+            }
             Object::Error(idx) => {
                 idx.internal_define_own_property(agent, property_key, property_descriptor, gc)
             }
@@ -3082,6 +3133,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_has_property(agent, property_key, cache, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_has_property(agent, property_key, cache, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_has_property(agent, property_key, cache, gc),
             Object::Error(data) => data.try_has_property(agent, property_key, cache, gc),
             Object::BoundFunction(data) => data.try_has_property(agent, property_key, cache, gc),
             Object::BuiltinFunction(data) => data.try_has_property(agent, property_key, cache, gc),
@@ -3200,6 +3253,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_has_property(agent, property_key, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_has_property(agent, property_key, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_has_property(agent, property_key, gc),
             Object::Error(data) => data.internal_has_property(agent, property_key, gc),
             Object::BoundFunction(data) => data.internal_has_property(agent, property_key, gc),
             Object::BuiltinFunction(data) => data.internal_has_property(agent, property_key, gc),
@@ -3316,6 +3371,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_get(agent, property_key, receiver, cache, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_get(agent, property_key, receiver, cache, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_get(agent, property_key, receiver, cache, gc),
             Object::Error(data) => data.try_get(agent, property_key, receiver, cache, gc),
             Object::BoundFunction(data) => data.try_get(agent, property_key, receiver, cache, gc),
             Object::BuiltinFunction(data) => data.try_get(agent, property_key, receiver, cache, gc),
@@ -3439,6 +3496,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_get(agent, property_key, receiver, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_get(agent, property_key, receiver, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_get(agent, property_key, receiver, gc),
             Object::Error(data) => data.internal_get(agent, property_key, receiver, gc),
             Object::BoundFunction(data) => data.internal_get(agent, property_key, receiver, gc),
             Object::BuiltinFunction(data) => data.internal_get(agent, property_key, receiver, gc),
@@ -3560,6 +3619,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             }
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_set(agent, property_key, value, receiver, cache, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_set(agent, property_key, value, receiver, cache, gc),
             Object::Error(data) => data.try_set(agent, property_key, value, receiver, cache, gc),
             Object::BoundFunction(data) => {
                 data.try_set(agent, property_key, value, receiver, cache, gc)
@@ -3759,6 +3820,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             }
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_set(agent, property_key, value, receiver, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_set(agent, property_key, value, receiver, gc),
             Object::Error(data) => data.internal_set(agent, property_key, value, receiver, gc),
             Object::BoundFunction(data) => {
                 data.internal_set(agent, property_key, value, receiver, gc)
@@ -3919,6 +3982,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_delete(agent, property_key, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_delete(agent, property_key, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_delete(agent, property_key, gc),
             Object::Error(data) => data.try_delete(agent, property_key, gc),
             Object::BoundFunction(data) => data.try_delete(agent, property_key, gc),
             Object::BuiltinFunction(data) => data.try_delete(agent, property_key, gc),
@@ -4025,6 +4090,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_delete(agent, property_key, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_delete(agent, property_key, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_delete(agent, property_key, gc),
             Object::Error(data) => data.internal_delete(agent, property_key, gc),
             Object::BoundFunction(data) => data.internal_delete(agent, property_key, gc),
             Object::BuiltinFunction(data) => data.internal_delete(agent, property_key, gc),
@@ -4134,6 +4201,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.try_own_property_keys(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.try_own_property_keys(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.try_own_property_keys(agent, gc),
             Object::Error(data) => data.try_own_property_keys(agent, gc),
             Object::BoundFunction(data) => data.try_own_property_keys(agent, gc),
             Object::BuiltinFunction(data) => data.try_own_property_keys(agent, gc),
@@ -4235,6 +4304,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.internal_own_property_keys(agent, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.internal_own_property_keys(agent, gc),
             Object::Error(data) => data.internal_own_property_keys(agent, gc),
             Object::BoundFunction(data) => data.internal_own_property_keys(agent, gc),
             Object::BuiltinFunction(data) => data.internal_own_property_keys(agent, gc),
@@ -4343,6 +4414,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.get_own_property_at_offset(agent, offset, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.get_own_property_at_offset(agent, offset, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::Error(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::BoundFunction(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::BuiltinFunction(data) => data.get_own_property_at_offset(agent, offset, gc),
@@ -4458,6 +4531,8 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             Object::ArrayBuffer(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "date")]
             Object::Date(data) => data.set_at_offset(agent, props, offset, gc),
+            #[cfg(feature = "temporal")]
+            Object::Instant(data) => data.set_at_offset(agent, props, offset, gc),
             Object::Error(data) => data.set_at_offset(agent, props, offset, gc),
             Object::BoundFunction(data) => data.set_at_offset(agent, props, offset, gc),
             Object::BuiltinFunction(data) => data.set_at_offset(agent, props, offset, gc),
@@ -4604,6 +4679,8 @@ impl HeapMarkAndSweep for Object<'static> {
             Self::ArrayBuffer(data) => data.mark_values(queues),
             #[cfg(feature = "date")]
             Self::Date(data) => data.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            Self::Instant(data) => data.mark_values(queues),
             Self::Error(data) => data.mark_values(queues),
             Self::BoundFunction(data) => data.mark_values(queues),
             Self::BuiltinFunction(data) => data.mark_values(queues),
@@ -4691,6 +4768,8 @@ impl HeapMarkAndSweep for Object<'static> {
             Self::DataView(data) => data.sweep_values(compactions),
             #[cfg(feature = "date")]
             Self::Date(data) => data.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            Self::Instant(data) => data.sweep_values(compactions),
             Self::Error(data) => data.sweep_values(compactions),
             Self::FinalizationRegistry(data) => data.sweep_values(compactions),
             Self::Map(data) => data.sweep_values(compactions),
@@ -4784,6 +4863,8 @@ impl HeapSweepWeakReference for Object<'static> {
             Self::DataView(data) => data.sweep_weak_reference(compactions).map(Self::DataView),
             #[cfg(feature = "date")]
             Self::Date(data) => data.sweep_weak_reference(compactions).map(Self::Date),
+            #[cfg(feature = "temporal")]
+            Self::Instant(data) => data.sweep_weak_reference(compactions).map(Self::Instant),
             Self::Error(data) => data.sweep_weak_reference(compactions).map(Self::Error),
             Self::FinalizationRegistry(data) => data
                 .sweep_weak_reference(compactions)
@@ -4954,6 +5035,8 @@ impl TryFrom<HeapRootData> for Object<'_> {
             HeapRootData::DataView(data_view) => Ok(Self::DataView(data_view)),
             #[cfg(feature = "date")]
             HeapRootData::Date(date) => Ok(Self::Date(date)),
+            #[cfg(feature = "temporal")]
+            HeapRootData::Instant(instant) => Ok(Self::Instant(instant)),
             HeapRootData::Error(error) => Ok(Self::Error(error)),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 Ok(Self::FinalizationRegistry(finalization_registry))

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//#[cfg(feature = "temporal")]
+//use temporal_rs::Instant as Instant; // shadow regular instant, should probably change name to TemporalInstant
+
 use super::{
     BigInt, BigIntHeapData, IntoValue, Number, Numeric, OrdinaryObject, Primitive, String,
     StringHeapData, Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
@@ -10,6 +13,8 @@ use super::{
 use crate::ecmascript::builtins::date::Date;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::Instant as Instant;
 #[cfg(feature = "set")]
 use crate::ecmascript::builtins::{
     keyed_collections::set_objects::set_iterator_objects::set_iterator::SetIterator, set::Set,
@@ -166,6 +171,8 @@ pub enum Value<'a> {
     DataView(DataView<'a>),
     #[cfg(feature = "date")]
     Date(Date<'a>),
+    #[cfg(feature = "temporal")]
+    Instant(Instant<'a>),
     Error(Error<'a>),
     FinalizationRegistry(FinalizationRegistry<'a>),
     Map(Map<'a>),
@@ -264,6 +271,8 @@ pub(crate) const ARRAY_BUFFER_DISCRIMINANT: u8 =
     value_discriminant(Value::ArrayBuffer(ArrayBuffer::_def()));
 #[cfg(feature = "date")]
 pub(crate) const DATE_DISCRIMINANT: u8 = value_discriminant(Value::Date(Date::_def()));
+#[cfg(feature = "temporal")]
+pub(crate) const INSTANT_DISCRIMINANT: u8 = value_discriminant(Value::Instant(Instant::_def()));
 pub(crate) const ERROR_DISCRIMINANT: u8 = value_discriminant(Value::Error(Error::_def()));
 pub(crate) const BUILTIN_FUNCTION_DISCRIMINANT: u8 =
     value_discriminant(Value::BuiltinFunction(BuiltinFunction::_def()));
@@ -767,6 +776,11 @@ impl<'a> Value<'a> {
                 discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
+            #[cfg(feature = "temporal")]
+            Value::Instant(data) => {
+                discriminant.hash(hasher);
+                data.get_index().hash(hasher)
+            }
             Value::Error(data) => {
                 discriminant.hash(hasher);
                 data.get_index().hash(hasher);
@@ -1005,6 +1019,11 @@ impl<'a> Value<'a> {
             }
             #[cfg(feature = "date")]
             Value::Date(data) => {
+                discriminant.hash(hasher);
+                data.get_index().hash(hasher);
+            }
+            #[cfg(feature = "temporal")]
+            Value::Instant(data) => {
                 discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
@@ -1305,6 +1324,8 @@ impl Rootable for Value<'_> {
             Self::DataView(data_view) => Err(HeapRootData::DataView(data_view.unbind())),
             #[cfg(feature = "date")]
             Self::Date(date) => Err(HeapRootData::Date(date.unbind())),
+            #[cfg(feature = "temporal")]
+            Self::Instant(instant) => Err(HeapRootData::Instant(instant.unbind())),
             Self::Error(error) => Err(HeapRootData::Error(error.unbind())),
             Self::FinalizationRegistry(finalization_registry) => Err(
                 HeapRootData::FinalizationRegistry(finalization_registry.unbind()),
@@ -1444,6 +1465,8 @@ impl Rootable for Value<'_> {
             HeapRootData::DataView(data_view) => Some(Self::DataView(data_view)),
             #[cfg(feature = "date")]
             HeapRootData::Date(date) => Some(Self::Date(date)),
+            #[cfg(feature = "temporal")]
+            HeapRootData::Instant(instant) => Some(Self::Instant(instant)),
             HeapRootData::Error(error) => Some(Self::Error(error)),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 Some(Self::FinalizationRegistry(finalization_registry))
@@ -1564,6 +1587,7 @@ impl HeapMarkAndSweep for Value<'static> {
             Value::ArrayBuffer(data) => data.mark_values(queues),
             #[cfg(feature = "date")]
             Value::Date(data) => data.mark_values(queues),
+            Value::Instant(data) => data.mark_values(queues),
             Value::Error(data) => data.mark_values(queues),
             Value::BoundFunction(data) => data.mark_values(queues),
             Value::BuiltinFunction(data) => data.mark_values(queues),
@@ -1652,6 +1676,7 @@ impl HeapMarkAndSweep for Value<'static> {
             Value::ArrayBuffer(data) => data.sweep_values(compactions),
             #[cfg(feature = "date")]
             Value::Date(data) => data.sweep_values(compactions),
+            Value::Instant(data) => data.sweep_values(compactions),
             Value::Error(data) => data.sweep_values(compactions),
             Value::BoundFunction(data) => data.sweep_values(compactions),
             Value::BuiltinFunction(data) => data.sweep_values(compactions),
@@ -1756,6 +1781,8 @@ fn map_object_to_static_string_repr(value: Value) -> String<'static> {
         Object::Float16Array(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "date")]
         Object::Date(_) => BUILTIN_STRING_MEMORY._object_Object_,
+        #[cfg(feature = "temporal")]
+        Object::Instant(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "set")]
         Object::Set(_) | Object::SetIterator(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "shared-array-buffer")]

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -1312,6 +1312,8 @@ fn typeof_operator(agent: &Agent, val: Value, gc: NoGcScope) -> String<'static> 
         Value::Float16Array(_) => BUILTIN_STRING_MEMORY.object,
         #[cfg(feature = "date")]
         Value::Date(_)  => BUILTIN_STRING_MEMORY.object,
+        #[cfg(feature = "temporal")]
+        Value::Instant(_)  => BUILTIN_STRING_MEMORY.object,
         // 13. If val has a [[Call]] internal slot, return "function".
         Value::BoundFunction(_) | Value::BuiltinFunction(_) | Value::ECMAScriptFunction(_) |
         Value::BuiltinConstructorFunction(_) |

--- a/nova_vm/src/engine/rootable.rs
+++ b/nova_vm/src/engine/rootable.rs
@@ -9,6 +9,8 @@ pub(crate) use private::{HeapRootCollectionData, RootableCollectionSealed, Roota
 
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::Instant;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "array-buffer")]
@@ -17,6 +19,8 @@ use crate::ecmascript::builtins::{ArrayBuffer, data_view::DataView};
 use crate::ecmascript::builtins::{weak_map::WeakMap, weak_ref::WeakRef, weak_set::WeakSet};
 #[cfg(feature = "date")]
 use crate::ecmascript::types::DATE_DISCRIMINANT;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::types::INSTANT_DISCRIMINANT;
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::types::FLOAT_16_ARRAY_DISCRIMINANT;
 #[cfg(feature = "shared-array-buffer")]
@@ -108,6 +112,8 @@ pub mod private {
 
     #[cfg(feature = "date")]
     use crate::ecmascript::builtins::date::Date;
+    #[cfg(feature = "temporal")]
+    use crate::ecmascript::builtins::temporal::instant::Instant;
     #[cfg(feature = "shared-array-buffer")]
     use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
     #[cfg(feature = "array-buffer")]
@@ -194,6 +200,8 @@ pub mod private {
     impl RootableSealed for DataView<'_> {}
     #[cfg(feature = "date")]
     impl RootableSealed for Date<'_> {}
+    #[cfg(feature = "temporal")]
+    impl RootableSealed for Instant<'_> {}
     impl RootableSealed for ECMAScriptFunction<'_> {}
     impl RootableSealed for EmbedderObject<'_> {}
     impl RootableSealed for Error<'_> {}
@@ -491,6 +499,8 @@ pub enum HeapRootData {
     DataView(DataView<'static>) = DATA_VIEW_DISCRIMINANT,
     #[cfg(feature = "date")]
     Date(Date<'static>) = DATE_DISCRIMINANT,
+    #[cfg(feature = "temporal")]
+    Instant(Instant<'static>) = INSTANT_DISCRIMINANT,
     Error(Error<'static>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'static>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'static>) = MAP_DISCRIMINANT,
@@ -594,6 +604,8 @@ impl From<Object<'static>> for HeapRootData {
             Object::DataView(data_view) => Self::DataView(data_view),
             #[cfg(feature = "date")]
             Object::Date(date) => Self::Date(date),
+            #[cfg(feature = "temporal")]
+            Object::Instant(instant) => Self::Instant(instant),
             Object::Error(error) => Self::Error(error),
             Object::FinalizationRegistry(finalization_registry) => {
                 Self::FinalizationRegistry(finalization_registry)
@@ -727,6 +739,8 @@ impl HeapMarkAndSweep for HeapRootData {
             HeapRootData::DataView(data_view) => data_view.mark_values(queues),
             #[cfg(feature = "date")]
             HeapRootData::Date(date) => date.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            HeapRootData::Instant(instant) => instant.mark_values(queues),
             HeapRootData::Error(error) => error.mark_values(queues),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 finalization_registry.mark_values(queues)
@@ -853,6 +867,8 @@ impl HeapMarkAndSweep for HeapRootData {
             HeapRootData::DataView(data_view) => data_view.sweep_values(compactions),
             #[cfg(feature = "date")]
             HeapRootData::Date(date) => date.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            HeapRootData::Instant(date) => date.sweep_values(compactions),
             HeapRootData::Error(error) => error.sweep_values(compactions),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 finalization_registry.sweep_values(compactions)

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -31,6 +31,8 @@ pub(crate) use self::object_entry::{ObjectEntry, ObjectEntryPropertyDescriptor};
 use crate::ecmascript::builtins::date::data::DateHeapData;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::data::SharedArrayBufferRecord;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::InstantHeapData;
 #[cfg(feature = "array-buffer")]
 use crate::ecmascript::builtins::{
     ArrayBuffer, ArrayBufferHeapData,
@@ -146,6 +148,8 @@ pub(crate) struct Heap {
     pub(crate) data_view_byte_offsets: AHashMap<DataView<'static>, usize>,
     #[cfg(feature = "date")]
     pub(crate) dates: Vec<Option<DateHeapData<'static>>>,
+    #[cfg(feature = "temporal")]
+    pub(crate) instants: Vec<Option<InstantHeapData<'static>>>,
     pub(crate) ecmascript_functions: Vec<Option<ECMAScriptFunctionHeapData<'static>>>,
     /// ElementsArrays is where all keys and values arrays live;
     /// Element arrays are static arrays of Values plus
@@ -278,6 +282,8 @@ impl Heap {
             data_view_byte_offsets: AHashMap::with_capacity(0),
             #[cfg(feature = "date")]
             dates: Vec::with_capacity(1024),
+            #[cfg(feature = "temporal")]
+            instants: Vec::with_capacity(1024), // todo: assign appropriate value for instants
             ecmascript_functions: Vec::with_capacity(1024),
             elements: ElementArrays {
                 e2pow1: ElementArray2Pow1::with_capacity(1024),

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -18,6 +18,8 @@ use super::{
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::Instant;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "array-buffer")]
@@ -93,6 +95,8 @@ pub struct HeapBits {
     pub data_views: Box<[bool]>,
     #[cfg(feature = "date")]
     pub dates: Box<[bool]>,
+    #[cfg(feature = "temporal")]
+    pub instants: Box<[bool]>,
     pub declarative_environments: Box<[bool]>,
     pub e_2_1: Box<[(bool, u8)]>,
     pub e_2_2: Box<[(bool, u8)]>,
@@ -184,6 +188,8 @@ pub(crate) struct WorkQueues {
     pub data_views: Vec<DataView<'static>>,
     #[cfg(feature = "date")]
     pub dates: Vec<Date<'static>>,
+    #[cfg(feature = "temporal")]
+    pub instants: Vec<Instant<'static>>,
     pub declarative_environments: Vec<DeclarativeEnvironment<'static>>,
     pub e_2_1: Vec<(ElementIndex<'static>, u32)>,
     pub e_2_2: Vec<(ElementIndex<'static>, u32)>,
@@ -275,6 +281,8 @@ impl HeapBits {
         let data_views = vec![false; heap.data_views.len()];
         #[cfg(feature = "date")]
         let dates = vec![false; heap.dates.len()];
+        #[cfg(feature = "temporal")]
+        let instants = vec![false; heap.instants.len()];
         let declarative_environments = vec![false; heap.environments.declarative.len()];
         let e_2_1 = vec![(false, 0u8); heap.elements.e2pow1.values.len()];
         let e_2_2 = vec![(false, 0u8); heap.elements.e2pow2.values.len()];
@@ -363,6 +371,8 @@ impl HeapBits {
             data_views: data_views.into_boxed_slice(),
             #[cfg(feature = "date")]
             dates: dates.into_boxed_slice(),
+            #[cfg(feature = "temporal")]
+            instants: instants.into_boxed_slice(),
             declarative_environments: declarative_environments.into_boxed_slice(),
             e_2_1: e_2_1.into_boxed_slice(),
             e_2_2: e_2_2.into_boxed_slice(),
@@ -457,6 +467,8 @@ impl WorkQueues {
             data_views: Vec::with_capacity(heap.data_views.len() / 4),
             #[cfg(feature = "date")]
             dates: Vec::with_capacity(heap.dates.len() / 4),
+            #[cfg(feature = "temporal")]
+            instants: Vec::with_capacity(heap.instants.len() / 4),
             declarative_environments: Vec::with_capacity(heap.environments.declarative.len() / 4),
             e_2_1: Vec::with_capacity(heap.elements.e2pow1.values.len() / 4),
             e_2_2: Vec::with_capacity(heap.elements.e2pow2.values.len() / 4),
@@ -553,6 +565,8 @@ impl WorkQueues {
             data_views,
             #[cfg(feature = "date")]
             dates,
+            #[cfg(feature = "temporal")]
+            instants,
             declarative_environments,
             e_2_1,
             e_2_2,
@@ -663,6 +677,7 @@ impl WorkQueues {
             && caches.is_empty()
             && data_views.is_empty()
             && dates.is_empty()
+            && instants.is_empty()
             && declarative_environments.is_empty()
             && e_2_1.is_empty()
             && e_2_2.is_empty()
@@ -1015,6 +1030,8 @@ pub(crate) struct CompactionLists {
     pub data_views: CompactionList,
     #[cfg(feature = "date")]
     pub dates: CompactionList,
+    #[cfg(feature = "temporal")]
+    pub instants: CompactionList,
     pub declarative_environments: CompactionList,
     pub e_2_1: CompactionList,
     pub e_2_2: CompactionList,
@@ -1149,6 +1166,8 @@ impl CompactionLists {
             source_codes: CompactionList::from_mark_bits(&bits.source_codes),
             #[cfg(feature = "date")]
             dates: CompactionList::from_mark_bits(&bits.dates),
+            #[cfg(feature = "temporal")]
+            instants: CompactionList::from_mark_bits(&bits.instants),
             errors: CompactionList::from_mark_bits(&bits.errors),
             executables: CompactionList::from_mark_bits(&bits.executables),
             maps: CompactionList::from_mark_bits(&bits.maps),

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -22,6 +22,8 @@ use super::{
 use super::{heap_bits::sweep_side_table_values, indexes::TypedArrayIndex};
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::instant::Instant;
 #[cfg(feature = "shared-array-buffer")]
 use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "array-buffer")]
@@ -128,6 +130,8 @@ pub fn heap_gc(agent: &mut Agent, root_realms: &mut [Option<Realm<'static>>], gc
                 data_view_byte_offsets: _,
             #[cfg(feature = "date")]
             dates,
+            #[cfg(feature = "temporal")]
+            instants,
             ecmascript_functions,
             elements,
             embedder_objects,
@@ -556,6 +560,22 @@ pub fn heap_gc(agent: &mut Agent, root_realms: &mut [Option<Realm<'static>>], gc
                     }
                     *marked = true;
                     dates.get(index).mark_values(&mut queues);
+                }
+            });
+        }
+        #[cfg(feature = "date")]
+        {
+            let mut instant_marks: Box<[Instant]> = queues.instants.drain(..).collect();
+            instant_marks.sort();
+            instant_marks.iter().for_each(|&idx| {
+                let index = idx.get_index();
+                if let Some(marked) = bits.instants.get_mut(index) {
+                    if *marked {
+                        // Already marked, ignore
+                        return;
+                    }
+                    *marked = true;
+                    instants.get(index).mark_values(&mut queues);
                 }
             });
         }
@@ -1415,6 +1435,8 @@ fn sweep(
         data_view_byte_offsets,
         #[cfg(feature = "date")]
         dates,
+        #[cfg(feature = "temporal")]
+        instants,
         ecmascript_functions,
         elements,
         embedder_objects,
@@ -1785,6 +1807,12 @@ fn sweep(
         if !dates.is_empty() {
             s.spawn(|| {
                 sweep_heap_vector_values(dates, &compactions, &bits.dates);
+            });
+        }
+        #[cfg(feature = "temporal")]
+        if !instants.is_empty() {
+            s.spawn(|| {
+                sweep_heap_vector_values(instants, &compactions, &bits.instants);
             });
         }
         if !declarative.is_empty() {


### PR DESCRIPTION
This just adds all necessary backing/plumbing within the heap/ and the engine/ needed to add values and objects for %temporal.instant%. This somewhat naively follows %Date% and [RegExpIterator](https://github.com/trynova/nova/pull/826/commits/bee53d19fcb38fb3a4de89613aaf4bdf4c99eaee) implementations, since most of the work needed in heap/ and engine/ seemed repetitive. Actual implementation of %Temporal.Instant% heap and handle functionality remains unimplemented as todo!() studs.
 