### PR TITLE
Zoned date time stubs

### DIFF
--- a/nova_vm/src/builtin_strings
+++ b/nova_vm/src/builtin_strings
@@ -456,6 +456,7 @@ SyntaxError
 #[cfg(feature = "temporal")]Temporal.Duration
 #[cfg(feature = "temporal")]Temporal.Instant
 #[cfg(feature = "temporal")]Temporal.PlainTime
+#[cfg(feature = "temporal")]Temporal.ZonedDateTime
 #[cfg(feature = "math")]tan
 #[cfg(feature = "math")]tanh
 #[cfg(feature = "regexp")]test
@@ -526,4 +527,5 @@ with
 withResolvers
 writable
 #[cfg(feature = "atomics")]xor
+#[cfg(feature = "temporal")]ZonedDateTime
 #[cfg(feature = "temporal")]years

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -19,6 +19,7 @@ use crate::ecmascript::builtins::data_view::data::SharedDataViewRecord;
 use crate::ecmascript::builtins::temporal::{
     duration::data::DurationHeapData, instant::data::InstantRecord,
     plain_time::data::PlainTimeHeapData,
+    zoned_date_time::data::ZonedDateTimeHeapData,
 };
 #[cfg(feature = "array-buffer")]
 use crate::ecmascript::types::try_get_result_into_value;
@@ -1703,6 +1704,11 @@ pub(crate) fn ordinary_object_create_with_intrinsics<'a>(
             .heap
             .create(PlainTimeHeapData::default())
             .into_object(),
+        #[cfg(feature = "temporal")]
+        ProtoIntrinsics::TemporalZonedDateTime => agent
+            .heap
+            .create(ZonedDateTimeHeapData::default())
+            .into_object(),
         ProtoIntrinsics::TypeError => agent
             .heap
             .create(ErrorHeapData::new(ExceptionType::TypeError, None, None))
@@ -2098,6 +2104,9 @@ fn get_intrinsic_constructor<'a>(
         #[cfg(feature = "temporal")]
         ProtoIntrinsics::TemporalPlainTime => {
             Some(intrinsics.temporal_plain_time().into_function())
+        }
+        ProtoIntrinsics::TemporalZonedDateTime => {
+            Some(intrinsics.temporal_zoned_date_time().into_function())
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/temporal.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod instant;
 pub mod options;
 pub mod plain_time;
+pub mod zoned_date_time;
 
 use temporal_rs::{
     options::{DifferenceSettings, RoundingIncrement, RoundingMode, Unit, UnitGroup},

--- a/nova_vm/src/ecmascript/builtins/temporal/duration/data.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/duration/data.rs
@@ -9,7 +9,7 @@ use crate::{
     heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DurationHeapData<'a> {
     pub(crate) object_index: Option<OrdinaryObject<'a>>,
     pub(crate) duration: temporal_rs::Duration,

--- a/nova_vm/src/ecmascript/builtins/temporal/instant/instant_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/instant/instant_prototype.rs
@@ -516,23 +516,53 @@ impl TemporalInstantPrototype {
     }
 
     /// ### [8.3.12 Temporal.Instant.prototype.toLocaleString ( [ locales [ , options ] ] )](https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tolocalestring)
+    /// An ECMAScript implementation that includes the ECMA-402 Internationalization API 
+    /// must implement this method as specified in the ECMA-402 specification. 
+    /// If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
+    ///
+    /// The meanings of the optional parameters to this method are defined in the ECMA-402 specification; 
+    /// implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
     fn to_locale_string<'gc>(
-        _agent: &mut Agent,
-        _this_value: Value,
+        agent: &mut Agent,
+        this_value: Value,
         _args: ArgumentsList,
-        mut _gc: GcScope<'gc, '_>,
+        gc: GcScope<'gc, '_>,
     ) -> JsResult<'gc, Value<'gc>> {
-        unimplemented!()
+        // 1. Let instant be the this value.
+        let value = this_value.bind(gc.nogc());
+        // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+        let instant = require_internal_slot_temporal_instant(agent, value, gc.nogc()).bind(gc.nogc());
+        // 3. Return TemporalInstantToString(instant, undefined, AUTO).
+        let options: ToStringRoundingOptions = ToStringRoundingOptions::default(); // defaults Precision to Auto
+        match instant.unbind()?
+            .inner_instant(agent)
+            .to_ixdtf_string(Some(TimeZone::utc()), options)
+        {
+            Ok(string) => Ok(Value::from_string(agent, string, gc.into_nogc())),
+            Err(err) => Err(temporal_err_to_js_err(agent, err, gc.into_nogc())),
+        }
     }
 
     /// ###[8.3.13 Temporal.Instant.prototype.toJSON ( )](https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson)
     fn to_json<'gc>(
-        _agent: &mut Agent,
-        _this_value: Value,
+        agent: &mut Agent,
+        this_value: Value,
         _args: ArgumentsList,
-        mut _gc: GcScope<'gc, '_>,
+        gc: GcScope<'gc, '_>,
     ) -> JsResult<'gc, Value<'gc>> {
-        unimplemented!()
+        // 1. Let instant be the this value.
+        let value = this_value.bind(gc.nogc());
+        // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+        let instant = require_internal_slot_temporal_instant(agent, value.unbind(), gc.nogc()).bind(gc.nogc());
+        // 3. Return TemporalInstantToString(instant, undefined, AUTO).
+        let options: ToStringRoundingOptions = ToStringRoundingOptions::default();
+        match instant.unbind()?
+            .inner_instant(agent)
+            .to_ixdtf_string(Some(TimeZone::utc()), options)
+        {
+            Ok(string) => Ok(Value::from_string(agent, string, gc.into_nogc())),
+            Err(err) => Err(temporal_err_to_js_err(agent, err, gc.into_nogc())),
+        }
     }
 
     /// ###[8.3.14 Temporal.Instant.prototype.valueOf ( )](https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof)
@@ -560,11 +590,18 @@ impl TemporalInstantPrototype {
 
     // [8.3.15 Temporal.Instant.prototype.toZonedDateTimeISO ( timeZone )](https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso)
     fn to_zoned_date_time_iso<'gc>(
-        _agent: &mut Agent,
-        _this_value: Value,
-        _args: ArgumentsList,
-        mut _gc: GcScope<'gc, '_>,
+        agent: &mut Agent,
+        this_value: Value,
+        args: ArgumentsList,
+        mut gc: GcScope<'gc, '_>,
     ) -> JsResult<'gc, Value<'gc>> {
+        // 1. Let instant be the this value.
+        let value = this_value.bind(gc.nogc());
+        // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+        let instant = require_internal_slot_temporal_instant(agent, value.unbind(), gc.nogc()).bind(gc.nogc());
+        // 3. Set timeZone to ? ToTemporalTimeZoneIdentifier(timeZone).
+        let time_zone = Some(TimeZone::utc());
+        // 4. Return ! CreateTemporalZonedDateTime(instant.[[EpochNanoseconds]], timeZone, "iso8601").
         unimplemented!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time.rs
@@ -1,0 +1,161 @@
+use std::ops::{Index, IndexMut};
+
+use crate::{
+    ecmascript::{
+        builtins::temporal::zoned_date_time::data::ZonedDateTimeHeapData,
+        execution::{Agent, ProtoIntrinsics},
+        types::{InternalMethods, InternalSlots, Object, OrdinaryObject, Value},
+    },
+    engine::{
+        context::{Bindable, bindable_handle},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+    },
+    heap::{
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WorkQueues, indexes::BaseIndex,
+    },
+};
+
+pub(crate) mod data;
+pub mod zoned_date_time_constructor;
+pub mod zoned_date_time_prototype;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct TemporalZonedDateTime<'a>(BaseIndex<'a, ZonedDateTimeHeapData<'static>>);
+
+impl TemporalZonedDateTime<'_> {
+    pub(crate) const fn _def() -> Self {
+        TemporalZonedDateTime(BaseIndex::from_u32_index(0))
+    }
+
+    pub(crate) const fn get_index(self) -> usize {
+        self.0.into_index()
+    }
+}
+
+bindable_handle!(TemporalZonedDateTime);
+
+impl<'a> From<TemporalZonedDateTime<'a>> for Value<'a> {
+    fn from(value: TemporalZonedDateTime<'a>) -> Self {
+        Value::ZonedDateTime(value)
+    }
+}
+impl<'a> From<TemporalZonedDateTime<'a>> for Object<'a> {
+    fn from(value: TemporalZonedDateTime<'a>) -> Self {
+        Object::ZonedDateTime(value)
+    }
+}
+impl<'a> TryFrom<Value<'a>> for TemporalZonedDateTime<'a> {
+    type Error = ();
+
+    fn try_from(value: Value<'a>) -> Result<Self, ()> {
+        match value {
+            Value::ZonedDateTime(idx) => Ok(idx),
+            _ => Err(()),
+        }
+    }
+}
+impl<'a> TryFrom<Object<'a>> for TemporalZonedDateTime<'a> {
+    type Error = ();
+
+    fn try_from(object: Object<'a>) -> Result<Self, ()> {
+        match object {
+            Object::ZonedDateTime(idx) => Ok(idx),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'a> InternalSlots<'a> for TemporalZonedDateTime<'a> {
+    const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::TemporalZonedDateTime;
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject<'static>> {
+        agent[self].object_index
+    }
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject<'static>) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+}
+
+impl<'a> InternalMethods<'a> for TemporalZonedDateTime<'a> {}
+
+// TODO: get rid of Index impls, replace with get/get_mut/get_direct/get_direct_mut functions
+impl Index<TemporalZonedDateTime<'_>> for Agent {
+    type Output = ZonedDateTimeHeapData<'static>;
+
+    fn index(&self, index: TemporalZonedDateTime<'_>) -> &Self::Output {
+        &self.heap.zoned_date_times[index]
+    }
+}
+
+impl IndexMut<TemporalZonedDateTime<'_>> for Agent {
+    fn index_mut(&mut self, index: TemporalZonedDateTime<'_>) -> &mut Self::Output {
+        &mut self.heap.zoned_date_times[index]
+    }
+}
+
+impl Index<TemporalZonedDateTime<'_>> for Vec<ZonedDateTimeHeapData<'static>> {
+    type Output = ZonedDateTimeHeapData<'static>;
+
+    fn index(&self, index: TemporalZonedDateTime<'_>) -> &Self::Output {
+        self.get(index.get_index())
+            .expect("heap acess out of bounds")
+    }
+}
+
+impl IndexMut<TemporalZonedDateTime<'_>> for Vec<ZonedDateTimeHeapData<'static>> {
+    fn index_mut(&mut self, index: TemporalZonedDateTime<'_>) -> &mut Self::Output {
+        self.get_mut(index.get_index())
+            .expect("heap access out of bounds")
+    }
+}
+
+impl Rootable for TemporalZonedDateTime<'_> {
+    type RootRepr = HeapRootRef;
+
+    fn to_root_repr(value: Self) -> Result<Self::RootRepr, HeapRootData> {
+        Err(HeapRootData::ZonedDateTime(value.unbind()))
+    }
+
+    fn from_root_repr(value: &Self::RootRepr) -> Result<Self, HeapRootRef> {
+        Err(*value)
+    }
+
+    fn from_heap_ref(heap_ref: HeapRootRef) -> Self::RootRepr {
+        heap_ref
+    }
+
+    fn from_heap_data(heap_data: HeapRootData) -> Option<Self> {
+        match heap_data {
+            HeapRootData::ZonedDateTime(object) => Some(object),
+            _ => None,
+        }
+    }
+}
+
+impl HeapMarkAndSweep for TemporalZonedDateTime<'static> {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        queues.zoned_date_times.push(*self);
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        compactions.zoned_date_times.shift_index(&mut self.0);
+    }
+}
+
+impl HeapSweepWeakReference for TemporalZonedDateTime<'static> {
+    fn sweep_weak_reference(self, compactions: &CompactionLists) -> Option<Self> {
+        compactions
+            .zoned_date_times
+            .shift_weak_index(self.0)
+            .map(Self)
+    }
+}
+
+impl<'a> CreateHeapData<ZonedDateTimeHeapData<'a>, TemporalZonedDateTime<'a>> for Heap {
+    fn create(&mut self, data: ZonedDateTimeHeapData<'a>) -> TemporalZonedDateTime<'a> {
+        self.zoned_date_times.push(data.unbind()); // temporal_rs::ZonedDateTime does not derive Copy and therefore cannot be bind/unbind, I think it has to be 'static because it is not thread safe.
+        self.alloc_counter += core::mem::size_of::<ZonedDateTimeHeapData<'static>>();
+        TemporalZonedDateTime(BaseIndex::last(&self.zoned_date_times))
+    }
+}

--- a/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/data.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/data.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{
+    ecmascript::types::OrdinaryObject,
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
+};
+
+#[derive(Debug, Clone, Copy)] // cannot derive copy because of temporal_rs::ZonedDateTime not deriving it 
+pub struct ZonedDateTimeHeapData<'a> {
+    pub(crate) object_index: Option<OrdinaryObject<'a>>,
+    pub(crate) zoned_date_time: temporal_rs::ZonedDateTime,
+}
+
+impl ZonedDateTimeHeapData<'_> {
+    pub fn default() -> Self {
+        todo!()
+    }
+}
+
+impl HeapMarkAndSweep for ZonedDateTimeHeapData<'static> {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        let Self {
+            object_index,
+            zoned_date_time: _,
+        } = self;
+
+        object_index.mark_values(queues);
+    }
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        let Self {
+            object_index,
+            zoned_date_time: _,
+        } = self;
+
+        object_index.sweep_values(compactions);
+    }
+}

--- a/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/data.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/data.rs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::NoGcScope;
 use crate::{
-    ecmascript::types::OrdinaryObject,
-    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
+    ecmascript::types::OrdinaryObject, engine::context::{bindable_handle, trivially_bindable}, heap::{CompactionLists, HeapMarkAndSweep, WorkQueues}
 };
 
-#[derive(Debug, Clone, Copy)] // cannot derive copy because of temporal_rs::ZonedDateTime not deriving it 
+#[derive(Debug, Clone)] // cannot derive copy because of temporal_rs::ZonedDateTime not deriving it 
 pub struct ZonedDateTimeHeapData<'a> {
     pub(crate) object_index: Option<OrdinaryObject<'a>>,
     pub(crate) zoned_date_time: temporal_rs::ZonedDateTime,
@@ -18,6 +18,9 @@ impl ZonedDateTimeHeapData<'_> {
         todo!()
     }
 }
+
+trivially_bindable!(temporal_rs::ZonedDateTime);
+bindable_handle!(ZonedDateTimeHeapData);
 
 impl HeapMarkAndSweep for ZonedDateTimeHeapData<'static> {
     fn mark_values(&self, queues: &mut WorkQueues) {

--- a/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/zoned_date_time_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/zoned_date_time_constructor.rs
@@ -1,0 +1,47 @@
+use crate::{
+    ecmascript::{
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
+        execution::{Agent, JsResult, Realm},
+        types::{BUILTIN_STRING_MEMORY, IntoObject, Object, String, Value},
+    },
+    engine::context::{GcScope, NoGcScope},
+    heap::IntrinsicConstructorIndexes,
+};
+
+pub(crate) struct TemporalZonedDateTimeConstructor;
+
+impl Builtin for TemporalZonedDateTimeConstructor {
+    const NAME: String<'static> = BUILTIN_STRING_MEMORY.ZonedDateTime;
+    const LENGTH: u8 = 1;
+    const BEHAVIOUR: Behaviour =
+        Behaviour::Constructor(TemporalZonedDateTimeConstructor::constructor);
+}
+
+impl BuiltinIntrinsicConstructor for TemporalZonedDateTimeConstructor {
+    const INDEX: IntrinsicConstructorIndexes = IntrinsicConstructorIndexes::TemporalZonedDateTime;
+}
+
+impl TemporalZonedDateTimeConstructor {
+    fn constructor<'gc>(
+        _agent: &mut Agent,
+        _: Value,
+        _args: ArgumentsList,
+        _new_target: Option<Object>,
+        mut _gc: GcScope<'gc, '_>,
+    ) -> JsResult<'gc, Value<'gc>> {
+        unimplemented!()
+    }
+
+    pub(crate) fn create_intrinsic(agent: &mut Agent, realm: Realm<'static>, _gc: NoGcScope) {
+        let intrinsics = agent.get_realm_record_by_id(realm).intrinsics();
+        let zoned_date_time_prototype = intrinsics.temporal_zoned_date_time_prototype();
+
+        BuiltinFunctionBuilder::new_intrinsic_constructor::<TemporalZonedDateTimeConstructor>(
+            agent, realm,
+        )
+        .with_property_capacity(1)
+        .with_prototype_property(zoned_date_time_prototype.into_object())
+        .build();
+    }
+}

--- a/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/zoned_date_time_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/zoned_date_time_prototype.rs
@@ -1,0 +1,33 @@
+use crate::{
+    ecmascript::{
+        builders::ordinary_object_builder::OrdinaryObjectBuilder,
+        execution::{Agent, Realm},
+        types::BUILTIN_STRING_MEMORY,
+    },
+    engine::context::NoGcScope,
+    heap::WellKnownSymbolIndexes,
+};
+
+pub(crate) struct TemporalZonedDateTimePrototype;
+impl TemporalZonedDateTimePrototype {
+    pub fn create_intrinsic(agent: &mut Agent, realm: Realm<'static>, _: NoGcScope) {
+        let intrinsics = agent.get_realm_record_by_id(realm).intrinsics();
+        let this = intrinsics.temporal_zoned_date_time_prototype();
+        let object_prototype = intrinsics.object_prototype();
+        let zoned_date_time_constructor = intrinsics.temporal_zoned_date_time();
+
+        OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
+            .with_property_capacity(2)
+            .with_prototype(object_prototype)
+            .with_constructor_property(zoned_date_time_constructor)
+            .with_property(|builder| {
+                builder
+                    .with_key(WellKnownSymbolIndexes::ToStringTag.into())
+                    .with_value_readonly(BUILTIN_STRING_MEMORY.Temporal_ZonedDateTime.into())
+                    .with_enumerable(false)
+                    .with_configurable(true)
+                    .build()
+            })
+            .build();
+    }
+}

--- a/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
+++ b/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
@@ -54,6 +54,10 @@ use crate::ecmascript::builtins::temporal::{
         plain_time_constructor::TemporalPlainTimeConstructor,
         plain_time_prototype::TemporalPlainTimePrototype,
     },
+    zoned_date_time::{
+        zoned_date_time_constructor::TemporalZonedDateTimeConstructor,
+        zoned_date_time_prototype::TemporalZonedDateTimePrototype,
+    }
 };
 
 #[cfg(feature = "regexp")]
@@ -250,6 +254,8 @@ pub enum ProtoIntrinsics {
     TemporalDuration,
     #[cfg(feature = "temporal")]
     TemporalPlainTime,
+    #[cfg(feature = "temporal")]
+    TemporalZonedDateTime,
     TypeError,
     #[cfg(feature = "array-buffer")]
     Uint16Array,
@@ -345,6 +351,10 @@ impl Intrinsics {
         TemporalPlainTimePrototype::create_intrinsic(agent, realm, gc);
         #[cfg(feature = "temporal")]
         TemporalPlainTimeConstructor::create_intrinsic(agent, realm, gc);
+        #[cfg(feature = "temporal")]
+        TemporalZonedDateTimePrototype::create_intrinsic(agent, realm, gc);
+        #[cfg(feature = "temporal")]
+        TemporalZonedDateTimeConstructor::create_intrinsic(agent, realm, gc);
         #[cfg(feature = "date")]
         DatePrototype::create_intrinsic(agent, realm);
         #[cfg(feature = "date")]
@@ -460,6 +470,8 @@ impl Intrinsics {
             ProtoIntrinsics::TemporalDuration => self.temporal_duration().into(),
             #[cfg(feature = "temporal")]
             ProtoIntrinsics::TemporalPlainTime => self.temporal_plain_time().into(),
+            #[cfg(feature = "temporal")]
+            ProtoIntrinsics::TemporalZonedDateTime => self.temporal_zoned_date_time().into(),
             ProtoIntrinsics::TypeError => self.type_error().into(),
             ProtoIntrinsics::URIError => self.uri_error().into(),
             ProtoIntrinsics::AggregateError => self.aggregate_error().into(),
@@ -555,6 +567,8 @@ impl Intrinsics {
             ProtoIntrinsics::TemporalDuration => self.temporal_duration_prototype().into(),
             #[cfg(feature = "temporal")]
             ProtoIntrinsics::TemporalPlainTime => self.temporal_plain_time_prototype().into(),
+            #[cfg(feature = "temporal")]
+            ProtoIntrinsics::TemporalZonedDateTime => self.temporal_zoned_date_time_prototype().into(),
             ProtoIntrinsics::TypeError => self.type_error_prototype().into(),
             ProtoIntrinsics::URIError => self.uri_error_prototype().into(),
             ProtoIntrinsics::AggregateError => self.aggregate_error_prototype().into(),
@@ -1060,43 +1074,64 @@ impl Intrinsics {
     pub(crate) const fn math(&self) -> OrdinaryObject<'static> {
         IntrinsicObjectIndexes::MathObject.get_backing_object(self.object_index_base)
     }
-
+    
+    #[cfg(feature="temporal")]
     /// %Temporal%
     pub(crate) const fn temporal(&self) -> OrdinaryObject<'static> {
         IntrinsicObjectIndexes::Temporal.get_backing_object(self.object_index_base)
     }
-
+    
+    #[cfg(feature="temporal")]
     /// %Temporal.Instant.Prototype%
     pub(crate) const fn temporal_duration_prototype(&self) -> OrdinaryObject<'static> {
         IntrinsicObjectIndexes::TemporalDurationPrototype.get_backing_object(self.object_index_base)
     }
 
+    #[cfg(feature="temporal")]
     /// %Temporal.Instant%
     pub(crate) const fn temporal_duration(&self) -> BuiltinFunction<'static> {
         IntrinsicConstructorIndexes::TemporalDuration
             .get_builtin_function(self.builtin_function_index_base)
     }
 
+    #[cfg(feature="temporal")]
     /// %Temporal.Instant.Prototype%
     pub(crate) const fn temporal_instant_prototype(&self) -> OrdinaryObject<'static> {
         IntrinsicObjectIndexes::TemporalInstantPrototype.get_backing_object(self.object_index_base)
     }
 
+    #[cfg(feature="temporal")]
     /// %Temporal.Instant%
     pub(crate) const fn temporal_instant(&self) -> BuiltinFunction<'static> {
         IntrinsicConstructorIndexes::TemporalInstant
             .get_builtin_function(self.builtin_function_index_base)
     }
 
+    #[cfg(feature="temporal")]
     /// %Temporal.PlainTime.prototype%
     pub(crate) const fn temporal_plain_time_prototype(&self) -> OrdinaryObject<'static> {
         IntrinsicObjectIndexes::TemporalPlainTimePrototype
             .get_backing_object(self.object_index_base)
     }
 
+    #[cfg(feature="temporal")]
     /// %Temporal.PlainTime%
     pub(crate) const fn temporal_plain_time(&self) -> BuiltinFunction<'static> {
         IntrinsicConstructorIndexes::TemporalPlainTime
+            .get_builtin_function(self.builtin_function_index_base)
+    }
+    
+    #[cfg(feature="temporal")]
+    /// %Temporal.PlainTime.prototype%
+    pub(crate) const fn temporal_zoned_date_time_prototype(&self) -> OrdinaryObject<'static> {
+        IntrinsicObjectIndexes::TemporalZonedDateTimePrototype
+            .get_backing_object(self.object_index_base)
+    }
+
+    #[cfg(feature="temporal")]
+    /// %Temporal.PlainTime%
+    pub(crate) const fn temporal_zoned_date_time(&self) -> BuiltinFunction<'static> {
+        IntrinsicConstructorIndexes::TemporalZonedDateTime
             .get_builtin_function(self.builtin_function_index_base)
     }
 

--- a/nova_vm/src/ecmascript/execution/weak_key.rs
+++ b/nova_vm/src/ecmascript/execution/weak_key.rs
@@ -17,9 +17,9 @@ use crate::ecmascript::types::{
 #[cfg(feature = "temporal")]
 use crate::ecmascript::{
     builtins::temporal::{
-        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime, zoned_date_time::TemporalZonedDateTime,
     },
-    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT},
+    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT, ZONED_DATE_TIME_DISCRIMINANT},
 };
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::{builtins::typed_array::Float16Array, types::FLOAT_16_ARRAY_DISCRIMINANT};
@@ -154,6 +154,8 @@ pub(crate) enum WeakKey<'a> {
     Duration(TemporalDuration<'a>) = DURATION_DISCRIMINANT,
     #[cfg(feature = "temporal")]
     PlainTime(TemporalPlainTime<'a>) = PLAIN_TIME_DISCRIMINANT,
+    #[cfg(feature = "temporal")]
+    ZonedDateTime(TemporalZonedDateTime<'a>) = ZONED_DATE_TIME_DISCRIMINANT,
     Error(Error<'a>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'a>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'a>) = MAP_DISCRIMINANT,
@@ -273,6 +275,8 @@ impl<'a> From<WeakKey<'a>> for Value<'a> {
             WeakKey::Duration(d) => Self::Duration(d),
             #[cfg(feature = "temporal")]
             WeakKey::PlainTime(d) => Self::PlainTime(d),
+            #[cfg(feature = "temporal")]
+            WeakKey::ZonedDateTime(d) => Self::ZonedDateTime(d),
             WeakKey::Error(d) => Self::Error(d),
             WeakKey::FinalizationRegistry(d) => Self::FinalizationRegistry(d),
             WeakKey::Map(d) => Self::Map(d),
@@ -386,6 +390,8 @@ impl<'a> From<Object<'a>> for WeakKey<'a> {
             Object::Duration(d) => Self::Duration(d),
             #[cfg(feature = "temporal")]
             Object::PlainTime(d) => Self::PlainTime(d),
+            #[cfg(feature = "temporal")]
+            Object::ZonedDateTime(d) => Self::ZonedDateTime(d),
             Object::Error(d) => Self::Error(d),
             Object::FinalizationRegistry(d) => Self::FinalizationRegistry(d),
             Object::Map(d) => Self::Map(d),
@@ -503,6 +509,8 @@ impl<'a> TryFrom<WeakKey<'a>> for Object<'a> {
             WeakKey::Duration(d) => Ok(Self::Duration(d)),
             #[cfg(feature = "temporal")]
             WeakKey::PlainTime(d) => Ok(Self::PlainTime(d)),
+            #[cfg(feature = "temporal")]
+            WeakKey::ZonedDateTime(d) => Ok(Self::ZonedDateTime(d)),
             WeakKey::Error(d) => Ok(Self::Error(d)),
             WeakKey::FinalizationRegistry(d) => Ok(Self::FinalizationRegistry(d)),
             WeakKey::Map(d) => Ok(Self::Map(d)),
@@ -651,6 +659,8 @@ impl HeapMarkAndSweep for WeakKey<'static> {
             Self::Duration(d) => d.mark_values(queues),
             #[cfg(feature = "temporal")]
             Self::PlainTime(d) => d.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(d) => d.mark_values(queues),
             Self::Error(d) => d.mark_values(queues),
             Self::FinalizationRegistry(d) => d.mark_values(queues),
             Self::Map(d) => d.mark_values(queues),
@@ -762,6 +772,8 @@ impl HeapMarkAndSweep for WeakKey<'static> {
             Self::Duration(d) => d.sweep_values(compactions),
             #[cfg(feature = "temporal")]
             Self::PlainTime(d) => d.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(d) => d.sweep_values(compactions),
             Self::Error(d) => d.sweep_values(compactions),
             Self::FinalizationRegistry(d) => d.sweep_values(compactions),
             Self::Map(d) => d.sweep_values(compactions),
@@ -889,6 +901,8 @@ impl HeapSweepWeakReference for WeakKey<'static> {
             Self::Duration(data) => data.sweep_weak_reference(compactions).map(Self::Duration),
             #[cfg(feature = "temporal")]
             Self::PlainTime(data) => data.sweep_weak_reference(compactions).map(Self::PlainTime),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(data) => data.sweep_weak_reference(compactions).map(Self::ZonedDateTime),
             Self::Error(data) => data.sweep_weak_reference(compactions).map(Self::Error),
             Self::FinalizationRegistry(data) => data
                 .sweep_weak_reference(compactions)

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -41,9 +41,9 @@ use crate::ecmascript::builtins::{weak_map::WeakMap, weak_ref::WeakRef, weak_set
 #[cfg(feature = "temporal")]
 use crate::ecmascript::{
     builtins::temporal::{
-        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime, zoned_date_time::TemporalZonedDateTime,
     },
-    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT},
+    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT, ZONED_DATE_TIME_DISCRIMINANT},
 };
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::{builtins::typed_array::Float16Array, types::FLOAT_16_ARRAY_DISCRIMINANT};
@@ -192,6 +192,8 @@ pub enum Object<'a> {
     Duration(TemporalDuration<'a>) = DURATION_DISCRIMINANT,
     #[cfg(feature = "temporal")]
     PlainTime(TemporalPlainTime<'a>) = PLAIN_TIME_DISCRIMINANT,
+    #[cfg(feature = "temporal")]
+    ZonedDateTime(TemporalZonedDateTime<'a>) = ZONED_DATE_TIME_DISCRIMINANT,
     Error(Error<'a>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'a>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'a>) = MAP_DISCRIMINANT,
@@ -796,6 +798,8 @@ impl<'a> From<Object<'a>> for Value<'a> {
             Object::Duration(data) => Value::Duration(data),
             #[cfg(feature = "temporal")]
             Object::PlainTime(data) => Value::PlainTime(data),
+            #[cfg(feature = "temporal")]
+            Object::ZonedDateTime(data) => Value::ZonedDateTime(data),
             Object::Error(data) => Self::Error(data),
             Object::FinalizationRegistry(data) => Self::FinalizationRegistry(data),
             Object::Map(data) => Self::Map(data),
@@ -910,6 +914,8 @@ impl<'a> TryFrom<Value<'a>> for Object<'a> {
             Value::Duration(x) => Ok(Self::Duration(x)),
             #[cfg(feature = "temporal")]
             Value::PlainTime(x) => Ok(Self::PlainTime(x)),
+            #[cfg(feature = "temporal")]
+            Value::ZonedDateTime(x) => Ok(Self::ZonedDateTime(x)),
             Value::Error(x) => Ok(Self::from(x)),
             Value::BoundFunction(x) => Ok(Self::from(x)),
             Value::BuiltinFunction(x) => Ok(Self::from(x)),
@@ -1032,6 +1038,8 @@ macro_rules! object_delegate {
             Object::Duration(data) => data.$method($($arg),+),
             #[cfg(feature = "temporal")]
             Object::PlainTime(data) => data.$method($($arg),+),
+            #[cfg(feature = "temporal")]
+            Object::ZonedDateTime(data) => data.$method($($arg),+),
             Self::Error(data) => data.$method($($arg),+),
             Self::BoundFunction(data) => data.$method($($arg),+),
             Self::BuiltinFunction(data) => data.$method($($arg),+),
@@ -1468,6 +1476,8 @@ impl HeapSweepWeakReference for Object<'static> {
             Self::Duration(data) => data.sweep_weak_reference(compactions).map(Self::Duration),
             #[cfg(feature = "temporal")]
             Self::PlainTime(data) => data.sweep_weak_reference(compactions).map(Self::PlainTime),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(data) => data.sweep_weak_reference(compactions).map(Self::ZonedDateTime),
             Self::Error(data) => data.sweep_weak_reference(compactions).map(Self::Error),
             Self::BoundFunction(data) => data
                 .sweep_weak_reference(compactions)
@@ -1710,6 +1720,8 @@ impl TryFrom<HeapRootData> for Object<'_> {
             HeapRootData::Duration(duration) => Ok(Self::Duration(duration)),
             #[cfg(feature = "temporal")]
             HeapRootData::PlainTime(plain_time) => Ok(Self::PlainTime(plain_time)),
+            #[cfg(feature = "temporal")]
+            HeapRootData::ZonedDateTime(zoned_date_time) => Ok(Self::ZonedDateTime(zoned_date_time)),
             HeapRootData::Error(error) => Ok(Self::Error(error)),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 Ok(Self::FinalizationRegistry(finalization_registry))

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -11,6 +11,7 @@ use crate::ecmascript::builtins::date::Date;
 #[cfg(feature = "temporal")]
 use crate::ecmascript::builtins::temporal::{
     duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+    zoned_date_time::{TemporalZonedDateTime},
 };
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::builtins::typed_array::Float16Array;
@@ -188,6 +189,8 @@ pub enum Value<'a> {
     Duration(TemporalDuration<'a>),
     #[cfg(feature = "temporal")]
     PlainTime(TemporalPlainTime<'a>),
+    #[cfg(feature = "temporal")]
+    ZonedDateTime(TemporalZonedDateTime<'a>),
     Error(Error<'a>),
     FinalizationRegistry(FinalizationRegistry<'a>),
     Map(Map<'a>),
@@ -333,6 +336,9 @@ pub(crate) const DURATION_DISCRIMINANT: u8 =
 #[cfg(feature = "temporal")]
 pub(crate) const PLAIN_TIME_DISCRIMINANT: u8 =
     value_discriminant(Value::PlainTime(TemporalPlainTime::_def()));
+#[cfg(feature = "temporal")]
+pub(crate) const ZONED_DATE_TIME_DISCRIMINANT: u8 =
+    value_discriminant(Value::ZonedDateTime(TemporalZonedDateTime::_def()));
 pub(crate) const ERROR_DISCRIMINANT: u8 = value_discriminant(Value::Error(Error::_def()));
 pub(crate) const BUILTIN_FUNCTION_DISCRIMINANT: u8 =
     value_discriminant(Value::BuiltinFunction(BuiltinFunction::_def()));
@@ -1013,6 +1019,8 @@ impl Rootable for Value<'_> {
             Self::Duration(duration) => Err(HeapRootData::Duration(duration.unbind())),
             #[cfg(feature = "temporal")]
             Self::PlainTime(plain_time) => Err(HeapRootData::PlainTime(plain_time.unbind())),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(zoned_date_time) => Err(HeapRootData::ZonedDateTime(zoned_date_time.unbind())),
             Self::Error(error) => Err(HeapRootData::Error(error.unbind())),
             Self::FinalizationRegistry(finalization_registry) => Err(
                 HeapRootData::FinalizationRegistry(finalization_registry.unbind()),
@@ -1180,6 +1188,8 @@ impl Rootable for Value<'_> {
             HeapRootData::Duration(duration) => Some(Self::Duration(duration)),
             #[cfg(feature = "temporal")]
             HeapRootData::PlainTime(plain_time) => Some(Self::PlainTime(plain_time)),
+            #[cfg(feature = "temporal")]
+            HeapRootData::ZonedDateTime(zoned_date_time) => Some(Self::ZonedDateTime(zoned_date_time)),
             HeapRootData::Error(error) => Some(Self::Error(error)),
             HeapRootData::FinalizationRegistry(finalization_registry) => {
                 Some(Self::FinalizationRegistry(finalization_registry))
@@ -1334,6 +1344,8 @@ impl HeapMarkAndSweep for Value<'static> {
             Self::Duration(data) => data.mark_values(queues),
             #[cfg(feature = "temporal")]
             Self::PlainTime(data) => data.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(data) => data.mark_values(queues),
             Self::Error(data) => data.mark_values(queues),
             Self::BoundFunction(data) => data.mark_values(queues),
             Self::BuiltinFunction(data) => data.mark_values(queues),
@@ -1454,6 +1466,8 @@ impl HeapMarkAndSweep for Value<'static> {
             Self::Duration(data) => data.sweep_values(compactions),
             #[cfg(feature = "temporal")]
             Self::PlainTime(data) => data.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(data) => data.sweep_values(compactions),
             Self::Error(data) => data.sweep_values(compactions),
             Self::BoundFunction(data) => data.sweep_values(compactions),
             Self::BuiltinFunction(data) => data.sweep_values(compactions),
@@ -1611,6 +1625,8 @@ fn map_object_to_static_string_repr(value: Value) -> String<'static> {
         Object::Duration(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "temporal")]
         Object::PlainTime(_) => BUILTIN_STRING_MEMORY._object_Object_,
+        #[cfg(feature = "temporal")]
+        Object::ZonedDateTime(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "set")]
         Object::Set(_) | Object::SetIterator(_) => BUILTIN_STRING_MEMORY._object_Object_,
         #[cfg(feature = "weak-refs")]

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -1332,6 +1332,8 @@ fn typeof_operator(agent: &Agent, val: Value, gc: NoGcScope) -> String<'static> 
         Value::Duration(_)  => BUILTIN_STRING_MEMORY.object,
         #[cfg(feature = "temporal")]
         Value::PlainTime(_) => BUILTIN_STRING_MEMORY.object,
+        #[cfg(feature = "temporal")]
+        Value::ZonedDateTime(_) => BUILTIN_STRING_MEMORY.object,
         // 13. If val has a [[Call]] internal slot, return "function".
         Value::BoundFunction(_) | Value::BuiltinFunction(_) | Value::ECMAScriptFunction(_) |
         Value::BuiltinConstructorFunction(_) |

--- a/nova_vm/src/engine/rootable.rs
+++ b/nova_vm/src/engine/rootable.rs
@@ -20,9 +20,9 @@ use crate::ecmascript::types::{
 #[cfg(feature = "temporal")]
 use crate::ecmascript::{
     builtins::temporal::{
-        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime, zoned_date_time::TemporalZonedDateTime,
     },
-    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT},
+    types::{DURATION_DISCRIMINANT, INSTANT_DISCRIMINANT, PLAIN_TIME_DISCRIMINANT, ZONED_DATE_TIME_DISCRIMINANT},
 };
 #[cfg(feature = "proposal-float16array")]
 use crate::ecmascript::{builtins::typed_array::Float16Array, types::FLOAT_16_ARRAY_DISCRIMINANT};
@@ -144,7 +144,7 @@ pub mod private {
     use crate::ecmascript::builtins::date::Date;
     #[cfg(feature = "temporal")]
     use crate::ecmascript::builtins::temporal::{
-        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+        duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime, zoned_date_time::TemporalZonedDateTime,
     };
     #[cfg(feature = "shared-array-buffer")]
     use crate::ecmascript::builtins::{
@@ -247,6 +247,8 @@ pub mod private {
     impl RootableSealed for TemporalDuration<'_> {}
     #[cfg(feature = "temporal")]
     impl RootableSealed for TemporalPlainTime<'_> {}
+    #[cfg(feature = "temporal")]
+    impl RootableSealed for TemporalZonedDateTime<'_> {}
     impl RootableSealed for ECMAScriptFunction<'_> {}
     impl RootableSealed for EmbedderObject<'_> {}
     impl RootableSealed for Error<'_> {}
@@ -567,6 +569,8 @@ pub enum HeapRootData {
     Duration(TemporalDuration<'static>) = DURATION_DISCRIMINANT,
     #[cfg(feature = "temporal")]
     PlainTime(TemporalPlainTime<'static>) = PLAIN_TIME_DISCRIMINANT,
+    #[cfg(feature = "temporal")]
+    ZonedDateTime(TemporalZonedDateTime<'static>) = ZONED_DATE_TIME_DISCRIMINANT,
     Error(Error<'static>) = ERROR_DISCRIMINANT,
     FinalizationRegistry(FinalizationRegistry<'static>) = FINALIZATION_REGISTRY_DISCRIMINANT,
     Map(Map<'static>) = MAP_DISCRIMINANT,
@@ -707,6 +711,8 @@ impl From<Object<'static>> for HeapRootData {
             Object::Duration(duration) => Self::Duration(duration),
             #[cfg(feature = "temporal")]
             Object::PlainTime(plain_time) => Self::PlainTime(plain_time),
+            #[cfg(feature = "temporal")]
+            Object::ZonedDateTime(zoned_date_time) => Self::ZonedDateTime(zoned_date_time),
             Object::Error(error) => Self::Error(error),
             Object::FinalizationRegistry(finalization_registry) => {
                 Self::FinalizationRegistry(finalization_registry)
@@ -872,6 +878,8 @@ impl HeapMarkAndSweep for HeapRootData {
             Self::Duration(duration) => duration.mark_values(queues),
             #[cfg(feature = "temporal")]
             Self::PlainTime(plain_time) => plain_time.mark_values(queues),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(zoned_date_time) => zoned_date_time.mark_values(queues),
             Self::Error(error) => error.mark_values(queues),
             Self::FinalizationRegistry(finalization_registry) => {
                 finalization_registry.mark_values(queues)
@@ -1027,6 +1035,8 @@ impl HeapMarkAndSweep for HeapRootData {
             Self::Duration(duration) => duration.sweep_values(compactions),
             #[cfg(feature = "temporal")]
             Self::PlainTime(plain_time) => plain_time.sweep_values(compactions),
+            #[cfg(feature = "temporal")]
+            Self::ZonedDateTime(zoned_date_time) => zoned_date_time.sweep_values(compactions),
             Self::Error(error) => error.sweep_values(compactions),
             Self::FinalizationRegistry(finalization_registry) => {
                 finalization_registry.sweep_values(compactions)

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -33,6 +33,7 @@ use crate::ecmascript::builtins::date::data::DateHeapData;
 use crate::ecmascript::builtins::temporal::{
     duration::data::DurationHeapData, instant::data::InstantRecord,
     plain_time::data::PlainTimeHeapData,
+    zoned_date_time::data::ZonedDateTimeHeapData,
 };
 #[cfg(feature = "array-buffer")]
 use crate::ecmascript::builtins::{
@@ -156,6 +157,8 @@ pub(crate) struct Heap {
     pub(crate) durations: Vec<DurationHeapData<'static>>,
     #[cfg(feature = "temporal")]
     pub(crate) plain_times: Vec<PlainTimeHeapData<'static>>,
+    #[cfg(feature = "temporal")]
+    pub(crate) zoned_date_times: Vec<ZonedDateTimeHeapData<'static>>,
     pub(crate) ecmascript_functions: Vec<ECMAScriptFunctionHeapData<'static>>,
     /// ElementsArrays is where all keys and values arrays live;
     /// Element arrays are static arrays of Values plus
@@ -310,6 +313,8 @@ impl Heap {
             durations: Vec::with_capacity(1024),
             #[cfg(feature = "temporal")]
             plain_times: Vec::with_capacity(1024),
+            #[cfg(feature = "temporal")]
+            zoned_date_times: Vec::with_capacity(1024),
             ecmascript_functions: Vec::with_capacity(1024),
             elements: ElementArrays {
                 e2pow1: ElementArray2Pow1::with_capacity(1024),

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::ecmascript::builtins::date::Date;
 #[cfg(feature = "temporal")]
 use crate::ecmascript::builtins::temporal::{
-    duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime,
+    duration::TemporalDuration, instant::TemporalInstant, plain_time::TemporalPlainTime, zoned_date_time::{self, TemporalZonedDateTime},
 };
 #[cfg(feature = "array-buffer")]
 use crate::ecmascript::builtins::{ArrayBuffer, data_view::DataView, typed_array::VoidArray};
@@ -463,6 +463,8 @@ pub(crate) struct HeapBits {
     pub(super) plain_times: BitRange,
     #[cfg(feature = "temporal")]
     pub(super) durations: BitRange,
+    #[cfg(feature = "temporal")]
+    pub(super) zoned_date_times: BitRange,
     pub(super) declarative_environments: BitRange,
     pub(super) ecmascript_functions: BitRange,
     pub(super) embedder_objects: BitRange,
@@ -545,6 +547,8 @@ pub(crate) struct WorkQueues<'a> {
     pub(crate) plain_times: Vec<TemporalPlainTime<'static>>,
     #[cfg(feature = "temporal")]
     pub(crate) durations: Vec<TemporalDuration<'static>>,
+    #[cfg(feature = "temporal")]
+    pub(crate) zoned_date_times: Vec<TemporalZonedDateTime<'static>>,
     pub(crate) declarative_environments: Vec<DeclarativeEnvironment<'static>>,
     pub(crate) e_2_1: Vec<ElementIndex<'static>>,
     pub(crate) e_2_2: Vec<ElementIndex<'static>>,
@@ -694,11 +698,14 @@ impl HeapBits {
         let data_views = BitRange::from_bit_count_and_len(&mut bit_count, heap.data_views.len());
         #[cfg(feature = "date")]
         let dates = BitRange::from_bit_count_and_len(&mut bit_count, heap.dates.len());
-        #[cfg(feature = "date")]
+        #[cfg(feature = "temporal")]
         let instants = BitRange::from_bit_count_and_len(&mut bit_count, heap.instants.len());
-        #[cfg(feature = "date")]
-        let plain_times = BitRange::from_bit_count_and_len(&mut bit_count, heap.plain_times.len());
+        #[cfg(feature = "temporal")]
         let durations = BitRange::from_bit_count_and_len(&mut bit_count, heap.durations.len());
+        #[cfg(feature = "temporal")]
+        let plain_times = BitRange::from_bit_count_and_len(&mut bit_count, heap.plain_times.len());
+        #[cfg(feature = "temporal")]
+        let zoned_date_times = BitRange::from_bit_count_and_len(&mut bit_count, heap.zoned_date_times.len());
         let declarative_environments =
             BitRange::from_bit_count_and_len(&mut bit_count, heap.environments.declarative.len());
         let ecmascript_functions =
@@ -812,6 +819,8 @@ impl HeapBits {
             plain_times,
             #[cfg(feature = "temporal")]
             durations,
+            #[cfg(feature = "temporal")]
+            zoned_date_times,
             declarative_environments,
             e_2_1,
             e_2_2,
@@ -928,6 +937,8 @@ impl HeapBits {
             WeakKey::PlainTime(d) => self.plain_times.get_bit(d.get_index(), &self.bits),
             #[cfg(feature = "temporal")]
             WeakKey::Duration(d) => self.durations.get_bit(d.get_index(), &self.bits),
+            #[cfg(feature = "temporal")]
+            WeakKey::ZonedDateTime(d) => self.zoned_date_times.get_bit(d.get_index(), &self.bits),
             WeakKey::Error(d) => self.errors.get_bit(d.get_index(), &self.bits),
             WeakKey::FinalizationRegistry(d) => self
                 .finalization_registrys
@@ -1071,6 +1082,8 @@ impl<'a> WorkQueues<'a> {
             durations: Vec::with_capacity(heap.durations.len() / 4),
             #[cfg(feature = "temporal")]
             plain_times: Vec::with_capacity(heap.plain_times.len() / 4),
+            #[cfg(feature = "temporal")]
+            zoned_date_times: Vec::with_capacity(heap.zoned_date_times.len() / 4),
             declarative_environments: Vec::with_capacity(heap.environments.declarative.len() / 4),
             e_2_1: Vec::with_capacity(heap.elements.e2pow1.values.len() / 4),
             e_2_2: Vec::with_capacity(heap.elements.e2pow2.values.len() / 4),
@@ -1183,6 +1196,8 @@ impl<'a> WorkQueues<'a> {
             durations,
             #[cfg(feature = "temporal")]
             plain_times,
+            #[cfg(feature = "temporal")]
+            zoned_date_times,
             declarative_environments,
             e_2_1,
             e_2_2,
@@ -1306,6 +1321,7 @@ impl<'a> WorkQueues<'a> {
             && instants.is_empty()
             && durations.is_empty()
             && plain_times.is_empty()
+            && zoned_date_times.is_empty()
             && declarative_environments.is_empty()
             && e_2_1.is_empty()
             && e_2_2.is_empty()
@@ -1671,6 +1687,8 @@ pub(crate) struct CompactionLists {
     pub(crate) plain_times: CompactionList,
     #[cfg(feature = "temporal")]
     pub(crate) durations: CompactionList,
+    #[cfg(feature = "temporal")]
+    pub(crate) zoned_date_times: CompactionList,
     pub(crate) declarative_environments: CompactionList,
     pub(crate) e_2_1: CompactionList,
     pub(crate) e_2_2: CompactionList,
@@ -1832,6 +1850,8 @@ impl CompactionLists {
             plain_times: CompactionList::from_mark_bits(&bits.plain_times, &bits.bits),
             #[cfg(feature = "temporal")]
             durations: CompactionList::from_mark_bits(&bits.durations, &bits.bits),
+            #[cfg(feature = "temporal")]
+            zoned_date_times: CompactionList::from_mark_bits(&bits.zoned_date_times, &bits.bits),
             errors: CompactionList::from_mark_bits(&bits.errors, &bits.bits),
             executables: CompactionList::from_mark_bits(&bits.executables, &bits.bits),
             maps: CompactionList::from_mark_bits(&bits.maps, &bits.bits),

--- a/nova_vm/src/heap/heap_constants.rs
+++ b/nova_vm/src/heap/heap_constants.rs
@@ -42,6 +42,8 @@ pub(crate) enum IntrinsicObjectIndexes {
     TemporalDurationPrototype,
     #[cfg(feature = "temporal")]
     TemporalPlainTimePrototype,
+    #[cfg(feature = "temporal")]
+    TemporalZonedDateTimePrototype,
 
     // Text processing
     #[cfg(feature = "regexp")]
@@ -185,6 +187,8 @@ pub(crate) enum IntrinsicConstructorIndexes {
     TemporalDuration,
     #[cfg(feature = "temporal")]
     TemporalPlainTime,
+    #[cfg(feature = "temporal")]
+    TemporalZonedDateTime,
 
     // Text processing
     String,

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -24,6 +24,8 @@ use crate::ecmascript::builtins::temporal::duration::TemporalDuration;
 use crate::ecmascript::builtins::temporal::instant::TemporalInstant;
 #[cfg(feature = "temporal")]
 use crate::ecmascript::builtins::temporal::plain_time::TemporalPlainTime;
+#[cfg(feature = "temporal")]
+use crate::ecmascript::builtins::temporal::zoned_date_time::TemporalZonedDateTime;
 #[cfg(feature = "array-buffer")]
 use crate::ecmascript::builtins::{ArrayBuffer, data_view::DataView, typed_array::VoidArray};
 #[cfg(feature = "shared-array-buffer")]
@@ -140,6 +142,8 @@ pub fn heap_gc(agent: &mut Agent, root_realms: &mut [Option<Realm<'static>>], gc
             durations,
             #[cfg(feature = "temporal")]
             plain_times,
+            #[cfg(feature = "temporal")]
+            zoned_date_times,
             ecmascript_functions,
             elements,
             embedder_objects,
@@ -588,6 +592,16 @@ pub fn heap_gc(agent: &mut Agent, root_realms: &mut [Option<Realm<'static>>], gc
                 if bits.plain_times.set_bit(index, &bits.bits) {
                     // Did mark.
                     plain_times.get(index).mark_values(&mut queues);
+                }
+            });
+            let mut zoned_date_time_marks: Box<[TemporalZonedDateTime]> =
+                queues.zoned_date_times.drain(..).collect();
+            zoned_date_time_marks.sort();
+            zoned_date_time_marks.iter().for_each(|&idx| {
+                let index = idx.get_index();
+                if bits.zoned_date_times.set_bit(index, &bits.bits) {
+                    // Did mark.
+                    zoned_date_times.get(index).mark_values(&mut queues);
                 }
             });
         }
@@ -1300,6 +1314,8 @@ fn sweep(
         durations,
         #[cfg(feature = "temporal")]
         plain_times,
+        #[cfg(feature = "temporal")]
+        zoned_date_times,
         ecmascript_functions,
         elements,
         embedder_objects,
@@ -1769,6 +1785,12 @@ fn sweep(
         if !plain_times.is_empty() {
             s.spawn(|| {
                 sweep_heap_vector_values(plain_times, &compactions, &bits.plain_times, &bits.bits);
+            });
+        }
+        #[cfg(feature = "temporal")]
+        if !zoned_date_times.is_empty() {
+            s.spawn(|| { // cannot be threaded because ZonedDateTime cannot be threaded?
+                sweep_heap_vector_values(zoned_date_times, &compactions, &bits.zoned_date_times, &bits.bits);
             });
         }
         if !declarative.is_empty() {


### PR DESCRIPTION
ZonedDateTime cannot do s.spawn, likely because of something in the ICU4X provider?
```rs
#[cfg(feature = "temporal")]
if !zoned_date_times.is_empty() {
    s.spawn(|| { // ZonedDateTime cannot be threaded?
    sweep_heap_vector_values(zoned_date_times, &compactions, &bits.zoned_date_times, &bits.bits);
    });
}
```

Error message:

```rs
error[E0277]: `Rc<std::boxed::Box<[u8]>>` cannot be sent between threads safely
    --> nova_vm/src/heap/heap_gc.rs:1792:21
     |
1792 |               s.spawn(|| { // cannot be threaded because ZonedDateTime cannot be threaded?
     |  _______________-----_^
     | |               |
     | |               required by a bound introduced by this call
1793 | |                 sweep_heap_vector_values(zoned_date_times, &compactions, &bits.zoned_date_times, &bits.bits);
1794 | |             });
     | |_____________^ `Rc<std::boxed::Box<[u8]>>` cannot be sent between threads safely
     |
     = help: the trait `Send` is not implemented for `Rc<std::boxed::Box<[u8]>>`
     = note: required for `yoke::cartable_ptr::CartableOptionPointer<Rc<std::boxed::Box<[u8]>>>` to implement `Sync`
note: required because it appears within the type `Yoke<JapaneseEras<'static>, CartableOptionPointer<Rc<Box<[u8]>>>>`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/yoke-0.8.1/src/yoke.rs:79:12
     |
  79 | pub struct Yoke<Y: for<'a> Yokeable<'a>, C> {
     |            ^^^^
note: required because it appears within the type `icu_provider::response::DataPayloadInner<icu_calendar::provider::CalendarJapaneseModernV1>`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/icu_provider-2.1.1/src/response.rs:155:17
     |
 155 | pub(crate) enum DataPayloadInner<M: DynamicDataMarker> {
     |                 ^^^^^^^^^^^^^^^^
note: required because it appears within the type `icu_provider::response::DataPayload<icu_calendar::provider::CalendarJapaneseModernV1>`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/icu_provider-2.1.1/src/response.rs:89:12
     |
  89 | pub struct DataPayload<M: DynamicDataMarker>(pub(crate) DataPayloadInner<M>);
     |            ^^^^^^^^^^^
note: required because it appears within the type `icu_calendar::cal::japanese::Japanese`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/icu_calendar-2.1.1/src/cal/japanese.rs:41:12
     |
  41 | pub struct Japanese {
     |            ^^^^^^^^
note: required because it appears within the type `icu_calendar::any_calendar::AnyCalendar`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/icu_calendar-2.1.1/src/any_calendar.rs:74:10
     |
  74 | pub enum AnyCalendar {
     |          ^^^^^^^^^^^
     = note: required for `&'static icu_calendar::any_calendar::AnyCalendar` to implement `Send`
note: required because it appears within the type `icu_calendar::date::Ref<'static, icu_calendar::any_calendar::AnyCalendar>`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/icu_calendar-2.1.1/src/date.rs:70:12
     |
  70 | pub struct Ref<'a, C>(pub &'a C);
     |            ^^^
note: required because it appears within the type `Calendar`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/temporal_rs-0.1.2/src/builtins/core/calendar.rs:56:12
     |
  56 | pub struct Calendar(Ref<'static, AnyCalendar>);
     |            ^^^^^^^^
note: required because it appears within the type `temporal_rs::ZonedDateTime`
    --> /Users/sebastianmatthews/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/temporal_rs-0.1.2/src/builtins/core/zoned_date_time.rs:255:12
     |
 255 | pub struct ZonedDateTime {
     |            ^^^^^^^^^^^^^
note: required because it appears within the type `ZonedDateTimeHeapData<'static>`
    --> nova_vm/src/ecmascript/builtins/temporal/zoned_date_time/data.rs:11:12
     |
  11 | pub struct ZonedDateTimeHeapData<'a> {
     |            ^^^^^^^^^^^^^^^^^^^^^
note: required because it appears within the type `PhantomData<ZonedDateTimeHeapData<'static>>`
    --> /Users/sebastianmatthews/.rustup/toolchains/1.91.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/marker.rs:822:12
     |
 822 | pub struct PhantomData<T: PointeeSized>;
     |            ^^^^^^^^^^^
note: required because it appears within the type `alloc::raw_vec::RawVec<ZonedDateTimeHeapData<'static>>`
    --> /Users/sebastianmatthews/.rustup/toolchains/1.91.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:74:19
     |
  74 | pub(crate) struct RawVec<T, A: Allocator = Global> {
     |                   ^^^^^^
note: required because it appears within the type `std::vec::Vec<ZonedDateTimeHeapData<'static>>`
    --> /Users/sebastianmatthews/.rustup/toolchains/1.91.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:434:12
     |
 434 | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
     |            ^^^
     = note: required because it appears within the type `&mut std::vec::Vec<ZonedDateTimeHeapData<'static>>`
note: required because it's used within this closure
    --> nova_vm/src/heap/heap_gc.rs:1792:21
     |
1792 |             s.spawn(|| { // cannot be threaded because ZonedDateTime cannot be threaded?
     |                     ^^
note: required by a bound in `Scope::<'scope, 'env>::spawn`
    --> /Users/sebastianmatthews/.rustup/toolchains/1.91.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/scoped.rs:197:28
     |
 195 |     pub fn spawn<F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
     |            ----- required by a bound in this associated function
 196 |     where
 197 |         F: FnOnce() -> T + Send + 'scope,
     |                            ^^^^ required by this bound in `Scope::<'scope, 'env>::spawn`
     = note: the full name for the type has been written to '/Users/sebastianmatthews/Documents/MAST/zinf/nova/target/debug/deps/nova_vm-087131a4d74017f1.long-type-6349248831440703772.txt'
     = note: consider using `--verbose` to print the full type name to the console
